### PR TITLE
link DOIs to preferred resolver

### DIFF
--- a/R/DT_format.R
+++ b/R/DT_format.R
@@ -42,7 +42,7 @@ DT_format <- function(x, authors=3, issue=FALSE, links=TRUE ){
                                            x$pmid, '_MED" target="_blank">', citedBy,  '</a>', sep=""))
        pmid <- paste0('<a href="http://europepmc.org/abstract/MED/', pmid, '" target="_blank">', pmid,  '</a>')
   # some dois missing
-    journal <-  ifelse(is.na(x$doi), journal, paste0('<a href="http://dx.doi.org/', x$doi, '" target="_blank">', journal,  '</a>') )
+    journal <-  ifelse(is.na(x$doi), journal, paste0('<a href="https://doi.org/', x$doi, '" target="_blank">', journal,  '</a>') )
 
    }
    x <- data.frame( pmid, authors, year, title, journal, citedBy)

--- a/R/bib_format.R
+++ b/R/bib_format.R
@@ -40,7 +40,7 @@ bib_format <- function(x, authors=3, issue=TRUE, links=FALSE, cited=FALSE, pmid=
        citedBy <- ifelse(citedBy == 0, 0,
                  paste('[', citedBy, '](http://europepmc.org/search?query=cites%3A', x$pmid, '_MED)', sep=""))
        x$pmid <- paste0('[', x$pmid, '](http://europepmc.org/abstract/MED/', x$pmid, ')' )
-      journal <-  ifelse(is.na(x$doi), journal, paste0('[', journal, '](http://dx.doi.org/', x$doi, ')') )
+      journal <-  ifelse(is.na(x$doi), journal, paste0('[', journal, '](https://doi.org/', x$doi, ')') )
    }
     ## ADD additional formats as option?
     y <-  paste0(authors, " ", year, ". ", title, " ", journal)


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by changing all static DOI links, as well as code that generates new ones.

Cheers :-)